### PR TITLE
chore: Check Pull Request Title

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -8,6 +8,15 @@ permissions:
   pull-requests: read
 
 jobs:
+  check-pr-title:
+    name: Check Pull Request Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Pull Request Title
+        uses: deepakputhraya/action-pr-title@v1.0.2
+        with:
+          allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: ,build(deps): " # title should start with the given prefix
+
   labeller:
     name: Label Pull Request
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new job to the GitHub Actions workflow for checking the pull request title. The most important changes include the addition of a new job named `check-pr-title` and the use of an action to enforce title prefixes.

Enhancements to GitHub Actions workflow:

* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfR11-R19): Added a new job `check-pr-title` to ensure pull request titles follow specified prefixes using `deepakputhraya/action-pr-title@v1.0.2`.

Fixes #23 
