### PR TITLE
ci: Validate Lefthook Configuration

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -133,3 +133,19 @@ jobs:
           queries: security-and-quality
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.28.15
+
+  lefthook-validate:
+    name: Lefthook Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        with:
+          version: "latest"
+      - name: Run Lefthook Validate
+        run: uvx lefthook validate


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub Actions job to validate code using Lefthook. The addition enhances the CI pipeline by incorporating a step to ensure pre-commit hook consistency across the repository.

### CI/CD Pipeline Enhancements:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R136-R151): Added a new `lefthook-validate` job to the workflow. This job checks out the repository, installs the latest version of `uv`, and runs `lefthook validate` to verify pre-commit hooks.