### PR TITLE
ci: Pin Github Actions

### DIFF
--- a/.github/other-configurations/pinact.yml
+++ b/.github/other-configurations/pinact.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+ignore_actions:
+  - name: actions/.*
+    ref: .*
+  - name: github/codeql-action/.*
+    ref: .*

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
       # Lint and Format everything
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.3.0
+        uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -64,7 +64,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.3.1
+        uses: UmbrellaDocs/action-linkspector@c6d4525e9f50b27a0e78fc42b537141058d034ef # v1.3.1
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -83,7 +83,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
       - name: Check Justfile Format
         run: just format-check
 
@@ -99,7 +99,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.2.2
+        uses: astral-sh/setup-uv@4db96194c378173c656ce18a155ffc14a9fc4355 # v5.2.2
         with:
           version: "latest"
       - name: Run zizmor 🌈

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Pull Request Title
-        uses: deepakputhraya/action-pr-title@v1.0.2
+        uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 # v1.0.2
         with:
           allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: ,build(deps): " # title should start with the given prefix
 
@@ -30,7 +30,7 @@ jobs:
           configuration-path: .github/other-configurations/labeller.yml
           sync-labels: true
       - name: Add Size Labels
-        uses: pascalgn/size-label-action@v0.5.5
+        uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Sync labels
-        uses: micnncim/action-label-syncer@v1.3.0
+        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}

--- a/Justfile
+++ b/Justfile
@@ -53,6 +53,22 @@ zizmor-check:
     zizmor .
 
 # ------------------------------------------------------------------------------
+# Pinact
+# ------------------------------------------------------------------------------
+
+# Run pinact
+pinact-run:
+    pinact run -c .github/other-configurations/pinact.yml
+
+# Run pinact checking
+pinact-check:
+    pinact run -c .github/other-configurations/pinact.yml --verify --check
+
+# Run pinact update
+pinact-update:
+    pinact run -c .github/other-configurations/pinact.yml --update
+
+# ------------------------------------------------------------------------------
 # Git Hooks
 # ------------------------------------------------------------------------------
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,3 +18,5 @@ pre-commit:
       run: just lefthook-validate
     Zizmor Checks:
       run: just zizmor-check
+    Pinact Checks:
+      run: just pinact-check


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces the configuration and integration of the `pinact` tool for managing GitHub Actions dependencies and updates several GitHub Actions to use pinned commit SHAs instead of version tags. These changes enhance security and reproducibility across workflows.

### Integration of `pinact`:
* Added a `pinact` configuration file (`.github/other-configurations/pinact.yml`) to define ignored actions and their references. This sets up the tool for managing and verifying pinned dependencies.
* Updated the `Justfile` to include commands for running, verifying, and updating `pinact` (`pinact-run`, `pinact-check`, and `pinact-update`).
* Added a `Pinact Checks` step to the `lefthook.yml` pre-commit configuration to ensure pinned dependencies are verified during pre-commit hooks.

### Pinned GitHub Actions:
* Updated multiple GitHub Actions across workflows (`code-checks.yml`, `pull-request-tasks.yml`, `sync-labels.yml`) to use commit SHAs instead of version tags, ensuring reproducibility and mitigating risks of unverified updates. Examples include:
  - `super-linter/super-linter/slim` pinned to `4e8a7c2b...`
  - `UmbrellaDocs/action-linkspector` pinned to `c6d4525e...`
  - `micnncim/action-label-syncer` pinned to `3abd5ab...`
