### PR TITLE
ci: Bump Major Versions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -64,7 +64,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@c6d4525e9f50b27a0e78fc42b537141058d034ef # v1.3.1
+        uses: UmbrellaDocs/action-linkspector@a0567ce1c7c13de4a2358587492ed43cab5d0102 # v1.3.4
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -83,7 +83,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Just
-        uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Check Justfile Format
         run: just format-check
 
@@ -99,7 +99,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@4db96194c378173c656ce18a155ffc14a9fc4355 # v5.2.2
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
         with:
           version: "latest"
       - name: Run zizmor 🌈
@@ -144,7 +144,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
         with:
           version: "latest"
       - name: Run Lefthook Validate


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions in the `.github/workflows/code-checks.yml` file to use newer versions of their respective actions. These updates ensure compatibility with the latest features and bug fixes.

### GitHub Actions Updates:

* Updated `UmbrellaDocs/action-linkspector` from version `v1.3.1` to `v1.3.4` to improve Markdown link checking.
* Updated `extractions/setup-just` from version `v2.0.0` to `v3` for setting up the Just command runner.
* Updated `astral-sh/setup-uv` from version `v5.2.2` to `v6.0.1` for installing the latest version of `uv`.
* Updated another instance of `astral-sh/setup-uv` from version `v5.4.2` to `v6.0.1` to ensure consistency across the workflow.
