### PR TITLE
ci: Change Jobs to Common Code Checks

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -52,63 +52,15 @@ jobs:
           VALIDATE_TSX: false
           VALIDATE_TSX_PRETTIER: false
 
-  check-markdown-links:
-    name: Check Markdown links
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@a0567ce1c7c13de4a2358587492ed43cab5d0102 # v1.3.4
-        with:
-          github_token: ${{ secrets.GH_TOKEN }}
-          config_file: .github/other-configurations/.linkspector.yml
-          reporter: github-pr-review
-          fail_on_error: true
-          filter_mode: nofilter
-          show_stats: true
-
-  check-justfile-format:
-    name: Check Justfile Format
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Set up Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
-      - name: Check Justfile Format
-        run: just format-check
-
-  run-zizmor:
-    name: Check GitHub Actions with zizmor
-    runs-on: ubuntu-latest
+  common-code-checks:
+    name: Common Code Checks
     permissions:
+      contents: read
+      pull-requests: read
       security-events: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
-      - name: Set up Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
-      - name: Run zizmor 🌈
-        run: just zizmor-check-sarif
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
-        with:
-          sarif_file: results.sarif
-          category: zizmor
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@14445779094fde883fdb9f65946fcae6c25f46c0 # v2025.05.14.01
+    secrets:
+      workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
   run-codeql-analysis:
     name: CodeQL Analysis
@@ -132,18 +84,3 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
 
-  lefthook-validate:
-    name: Lefthook Validate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
-        with:
-          version: "latest"
-      - name: Run Lefthook Validate
-        run: uvx lefthook validate

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -83,4 +83,3 @@ jobs:
           queries: security-and-quality
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
-


### PR DESCRIPTION
# Pull Request

## Description

This pull request simplifies the GitHub Actions workflow by consolidating multiple individual jobs into a reusable workflow. The changes aim to streamline maintenance and improve consistency across code checks.

### Workflow Consolidation:

* Removed individual jobs (`check-markdown-links`, `check-justfile-format`, `run-zizmor`, and `lefthook-validate`) and replaced them with a single reusable workflow named `common-code-checks`. This workflow is now referenced using `JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml`. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L55-R63) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L135-L149)

### Permissions and Secrets:

* Updated permissions for the `common-code-checks` workflow to include `contents: read`, `pull-requests: read`, and `security-events: write`. Additionally, configured the workflow to use the `GITHUB_TOKEN` secret.
