### PR TITLE
chore: Update Dependabot for Reusable Workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
           - "*"
         exclude-patterns:
           - "super-linter/super-linter"
-          - "JackPlowman/reusable-workflows/*"
+          - "JackPlowman/reusable-workflows"
         update-types:
           - "patch"
           - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small update to the `.github/dependabot.yml` file. The change modifies the `exclude-patterns` section by removing the wildcard from the `JackPlowman/reusable-workflows/*` pattern to exclude the entire `JackPlowman/reusable-workflows` directory instead.