### PR TITLE
ci: Migrate to Reusable CodeQL Analysis Workflow

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -62,6 +62,18 @@ jobs:
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
+  codeql-checks:
+    name: CodeQL Analysis
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      matrix:
+        language: [actions, typescript]
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@main
+    with:
+      language: ${{ matrix.language }}
+
   run-codeql-analysis:
     name: CodeQL Analysis
     runs-on: ubuntu-latest

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -73,25 +73,3 @@ jobs:
     uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@main
     with:
       language: ${{ matrix.language }}
-
-  run-codeql-analysis:
-    name: CodeQL Analysis
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-    strategy:
-      matrix:
-        language: [typescript, actions]
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
-        with:
-          languages: ${{ matrix.language }}
-          queries: security-and-quality
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -70,6 +70,6 @@ jobs:
     strategy:
       matrix:
         language: [actions, typescript]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@main
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@75ceb782a5815a98162de1321c852df74830a493 # v2025.05.24.01
     with:
       language: ${{ matrix.language }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the CodeQL analysis workflow in `.github/workflows/code-checks.yml` to simplify its configuration by switching to a reusable workflow. The change also includes minor adjustments to permissions and matrix definitions.

### Workflow simplification:
* Renamed the `run-codeql-analysis` job to `codeql-checks` and replaced the inline steps with a reusable workflow reference (`JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@75ceb782a5815a98162de1321c852df74830a493`).

### Configuration adjustments:
* Updated permissions to explicitly set `contents: read` and `security-events: write`.
* Adjusted the matrix definition to reorder the languages as `[actions, typescript]`.