### PR TITLE
chore: Update License to Licence

### DIFF
--- a/.github/tool-configurations/labeller.yml
+++ b/.github/tool-configurations/labeller.yml
@@ -21,7 +21,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the configuration for file labeling, correcting a file pattern in the documentation label group.

* Documentation label configuration: Changed the file pattern from `LICENSE` to `LICENCE` in the `markdown` section of `.github/other-configurations/labeller.yml` to match the actual file name.