### PR TITLE
build: Add Dashboard Just Commands

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+.venv
+.pytest_cache
+dashboard

--- a/dashboard/dashboard.just
+++ b/dashboard/dashboard.just
@@ -5,3 +5,35 @@
 # Install dependencies
 install:
     npm install
+
+# Install dependencies in workflow
+ci:
+    npm ci
+
+# Run the application in development mode
+dev:
+    npm run dev
+
+# Build the application for production
+build:
+    npm run build
+
+# Lint typescript code with ESLint
+lint:
+    npx eslint .
+
+# Lint typescript code with ESLint and generate a SARIF file
+eslint-with-sarif:
+    npx eslint . --format @microsoft/eslint-formatter-sarif --output-file eslint-results.sarif
+
+# ------------------------------------------------------------------------------
+# Prettier
+# ------------------------------------------------------------------------------
+
+# Check if code is formatted correctly
+prettier-check:
+    npx prettier . --check
+
+# Format code with Prettier
+prettier-format:
+    npx prettier . --check --write


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces improvements to the project tooling and workflow for the `dashboard` directory. The main changes include updating `.prettierignore` to exclude additional directories and files, and adding a comprehensive set of commands to the `dashboard.just` file to streamline development, CI, linting, and formatting tasks.

Project tooling updates:

* Updated `.prettierignore` to exclude `.venv`, `.pytest_cache`, and `dashboard` directories from Prettier formatting.

Development and CI workflow enhancements:

* Added new commands to `dashboard/dashboard.just` for installing dependencies (`install`, `ci`), running the development server (`dev`), and building the application (`build`).

Linting and formatting improvements:

* Added commands for linting with ESLint (`lint`, `eslint-with-sarif`) and formatting with Prettier (`prettier-check`, `prettier-format`) to `dashboard/dashboard.just`.
